### PR TITLE
Implement `DamageFormulaDialog` for `[[/damage]]` enrichers

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -93,6 +93,10 @@
         "DC": "Difficulty"
       },
       "DAMAGE": {
+        "ADD": "Add Damage",
+        "DELETE": "Delete this part",
+        "EXTENDED": "Extended",
+        "PARTS": "Damage Parts",
         "TITLE": "Damage Formula",
         "FORMULA_PRIMARY": "Primary Formula",
         "TYPE_PRIMARY": "Primary Type",
@@ -104,6 +108,7 @@
         "COMBINATION_AND": "And (Different formula & type)",
         "FORMULA": "Formula",
         "TYPE": "Damage Type",
+        "TYPES": "Damage Types",
         "AVERAGE": "Average",
         "USE_DICE": "Use Dice",
         "USE_AVERAGE": "Use Average"

--- a/scripts/applications/damage-formula.js
+++ b/scripts/applications/damage-formula.js
@@ -1,0 +1,223 @@
+const {HandlebarsApplicationMixin, ApplicationV2} = foundry.applications.api;
+const {ArrayField, BooleanField, SchemaField, SetField, StringField} = foundry.data.fields;
+
+/**
+ * @typedef {object} DamageConfig
+ * @property {string} formula     The damage formula.
+ * @property {string[]} types     The damage types.
+ */
+
+export default class DamageFormulaDialog extends HandlebarsApplicationMixin(ApplicationV2) {
+  /** @inheritdoc */
+  static DEFAULT_OPTIONS = {
+    classes: ["damage-formula-dialog"],
+    tag: "form",
+    form: {
+      handler: DamageFormulaDialog.handleFormSubmit,
+      submitOnChange: true,
+      closeOnSubmit: false,
+    },
+    position: {
+      width: 400,
+      height: "auto",
+    },
+    window: {
+      title: "DND.MENU.DIALOG",
+      contentClasses: ["standard-form"]
+    },
+    actions: {
+      addPart: DamageFormulaDialog.#addPart,
+      deletePart: DamageFormulaDialog.#deletePart,
+    },
+  };
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  static PARTS = {
+    config: {
+      template: "modules/dnd-easy-reference/templates/damage/config.hbs",
+    },
+    formulas: {
+      template: "modules/dnd-easy-reference/templates/damage/formulas.hbs",
+      scrollable: [""]
+    },
+    footer: {
+      template: "templates/generic/form-footer.hbs",
+    }
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * A data model to hold the data and perform runtime validation.
+   * @type {DamageFormulaModel}
+   */
+  #model = new DamageFormulaModel();
+
+  /* -------------------------------------------------- */
+
+  /**
+   * The text to inject.
+   * @type {string|null}
+   */
+  get text() {
+    let parts = [];
+    for (const { formula, types } of this.#model.parts) {
+      if (!formula) continue;
+      const type = types.size ? `type=${Array.from(types).join("|")}` : "";
+      parts.push([formula, type].join(" "));
+    }
+    if (!parts.length) return null;
+    parts = parts.join(" & ");
+
+    parts = [
+      parts,
+      this.#model.average ? "average" : null,
+      this.#model.extended ? "extended" : null,
+    ].filterJoin(" ");
+    return `[[/damage ${parts}]]`;
+  }
+
+  /* -------------------------------------------------- */
+
+  /** @inheritdoc */
+  async _prepareContext(options) {
+    const context = {};
+
+    const parts = context.parts = [];
+    for (const [i, part] of this.#model.parts.entries()) {
+      parts.push({
+        idx: i,
+        rule: i > 0,
+        formula: {
+          field: this.#model.schema.getField("parts.element.formula"),
+          value: part.formula,
+          placeholder: game.i18n.localize("DND.DIALOG.DAMAGE.FORMULA"),
+          name: `parts.${i}.formula`,
+        },
+        types: {
+          field: this.#model.schema.getField("parts.element.types"),
+          value: part.types,
+          name: `parts.${i}.types`,
+        },
+      })
+    }
+
+    context.average = {
+      field: this.#model.schema.getField("average"),
+      value: this.#model.average,
+    };
+
+    context.extended = {
+      field: this.#model.schema.getField("extended"),
+      value: this.#model.extended,
+    };
+
+    context.buttons = [{
+      type: "submit",
+      icon: "fa-solid fa-check",
+      label: "Confirm",
+    }];
+
+    return context;
+  }
+
+  /* -------------------------------------------------- */
+  /*   Event handlers                                   */
+  /* -------------------------------------------------- */
+
+  /**
+   * Handle form submission.
+   * @this {DamageFormulaDialog}
+   * @param {SubmitEvent} event             The submit event.
+   * @param {HTMLFormElement} form          The form element.
+   * @param {FormDataExtended} formData     The form data.
+   * @param {object} submitOptions          Submit options.
+   */
+  static handleFormSubmit(event, form, formData, submitOptions) {
+    if (event.type === "change") {
+      this.#model.updateSource(formData.object);
+    } else {
+      this.close();
+    }
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Add a new damage part.
+   * @this {DamageFormulaDialog}
+   * @param {PointerEvent} event      The initiating click event.
+   * @param {HTMLElement} target      The element that defined the [data-action].
+   */
+  static #addPart(event, target) {
+    const parts = this.#model.toObject().parts;
+    parts.push({ formula: "", types: [] });
+    this.#model.updateSource({ parts });
+    this.render({ parts: ["formulas"] });
+  }
+
+  /* -------------------------------------------------- */
+
+  /**
+   * Remove a damage part.
+   * @this {DamageFormulaDialog}
+   * @param {PointerEvent} event      The initiating click event.
+   * @param {HTMLElement} target      The element that defined the [data-action].
+   */
+  static #deletePart(event, target) {
+    const idx = parseInt(target.dataset.idx);
+    const parts = this.#model.toObject().parts;
+    parts.splice(idx, 1);
+    this.#model.updateSource({ parts });
+    this.render({ parts: ["formulas"] });
+  }
+
+  /* -------------------------------------------------- */
+  /*   Factory methods                                  */
+  /* -------------------------------------------------- */
+
+  /**
+   * Render an asynchronous instance of this application.
+   * @param {object} [options]            Rendering options.
+   * @returns {Promise<string|null>}      The text to inject, or `null` if the application was closed.
+   */
+  static async create(options = {}) {
+    const {promise, resolve, reject} = Promise.withResolvers();
+    const application = new this(options);
+    application.addEventListener("close", () => {
+      const text = application.text;
+      if (text) resolve(text);
+      else reject(null);
+    }, {once: true});
+    application.render({force: true});
+    return promise;
+  }
+}
+
+/* -------------------------------------------------- */
+
+/**
+ * Utility data model for holding onto the data across re-renders.
+ */
+class DamageFormulaModel extends foundry.abstract.DataModel {
+  /** @inheritdoc */
+  static defineSchema() {
+    return {
+      average: new BooleanField({
+        label: "DND.DIALOG.DAMAGE.AVERAGE",
+      }),
+      extended: new BooleanField({
+        label: "DND.DIALOG.DAMAGE.EXTENDED",
+      }),
+      parts: new ArrayField(new SchemaField({
+        formula: new dnd5e.dataModels.fields.FormulaField({ required: true }),
+        types: new SetField(new StringField({
+          required: true,
+          choices: CONFIG.DND5E.damageTypes,
+        })),
+      }))
+    };
+  }
+}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,4 +1,7 @@
 //region Constantes
+
+import DamageFormulaDialog from "./applications/damage-formula.js";
+
 // Configuration des menus
 const MENU_CONFIGS = {
   conditionTypes: 'conditionTypes',
@@ -43,6 +46,7 @@ const STYLE_BLOCKS = {
 Hooks.on("getProseMirrorMenuDropDowns", (proseMirrorMenu, dropdowns) => {
   // Fonction pour insérer du texte dans l'éditeur
   const insertText = (text) => {
+    if (!text) return;
     proseMirrorMenu.view.dispatch(
       proseMirrorMenu.view.state.tr.insertText(text).scrollIntoView()
     );
@@ -76,13 +80,9 @@ Hooks.on("getProseMirrorMenuDropDowns", (proseMirrorMenu, dropdowns) => {
     },
 
     // Dialogue pour les dégâts
-    damage: () => {
-      new DamageDialogV2({
-        callback: (damageString) => {
-          // Utiliser la fonction insertText qui est en portée
-          insertText(`[[/damage ${damageString}]]`);
-        }
-      }).render(true);
+    damage: async () => {
+      const text = await DamageFormulaDialog.create();
+      if (text) insertText(text);
     },
 
     // Dialogue pour les soins
@@ -385,74 +385,6 @@ export class CheckDialogV2 extends HandlebarsApplicationMixin(ApplicationV2) {
     return {
       abilities: CONFIG.DND5E.abilities,
       skills: CONFIG.DND5E.skills,
-      buttons: [
-        {
-          type: "submit",
-          icon: "fas fa-check",
-          label: "DND5E.Confirm"
-        }
-      ]
-    };
-  }
-}
-
-// Formule de dégâts
-export class DamageDialogV2 extends HandlebarsApplicationMixin(ApplicationV2) {
-  static DEFAULT_OPTIONS = {
-    id: "reference-dialog-v2",
-    tag: "form",
-    form: {
-      handler: DamageDialogV2.handleFormSubmit,
-      submitOnChange: false,
-      closeOnSubmit: true
-    },
-    window: {
-      title: "DND.MENU.DIALOG",
-      contentClasses: ["dialog-form"]
-    }
-  };
-  static PARTS = {
-    form: {
-      template: "modules/dnd-easy-reference/templates/damage-dialog.hbs"
-    },
-    footer: {
-      template: "templates/generic/form-footer.hbs",
-    }
-  }
-
-  static async handleFormSubmit(event, form, formData) {
-    // Récupérer les valeurs des champs
-    const formulaPrimary = formData.get("formulaPrimary");
-    const damageTypePrimary = formData.get("damageTypePrimary");
-    const combination = formData.get("combination");
-    const formulaSecondary = formData.get("formulaSecondary");
-    const damageTypeSecondary = formData.get("damageTypeSecondary");
-    const average = formData.get("average");
-
-    let damageFormula = '';
-
-    if (combination === "none") {
-
-      damageFormula = `formula=${formulaPrimary} type=${damageTypePrimary} average=${average}`;
-    } else if (combination === "or") {
-
-      damageFormula = `formula=${formulaPrimary} type=${damageTypePrimary}|${damageTypeSecondary} average=${average}`;
-    } else if (combination === "and") {
-
-      damageFormula = `formula=${formulaPrimary} type=${damageTypePrimary} & formula=${formulaSecondary} type=${damageTypeSecondary} average=${average}`;
-    }
-
-    this.callback(damageFormula);
-  }
-
-  constructor(data) {
-    super(data);
-    this.callback = data.callback;
-  }
-
-  async _prepareContext() {
-    return {
-      damageTypes: CONFIG.DND5E.damageTypes,
       buttons: [
         {
           type: "submit",

--- a/styles/menu-config.css
+++ b/styles/menu-config.css
@@ -179,3 +179,14 @@
 .dnd-widen-windows .app.window-app.dnd5e2.sheet.item .prosemirror menu {
   gap: 1px;
 }
+
+/* Damage Formula Dialog */
+.damage-formula-dialog {
+  .flex0 {
+    flex: 0;
+  }
+
+  .formulas {
+    overflow: auto;
+  }
+}

--- a/templates/damage/config.hbs
+++ b/templates/damage/config.hbs
@@ -1,0 +1,10 @@
+<fieldset>
+  {{ formGroup average.field value=average.value localize=true }}
+  {{ formGroup extended.field value=extended.value localize=true }}
+  <div class="form-group">
+    <label>{{localize "DND.DIALOG.DAMAGE.ADD"}}</label>
+    <button class="flex0" type="button" data-action="addPart">
+      <i class="fa-solid fa-plus"></i>
+    </button>
+  </div>
+</fieldset>

--- a/templates/damage/formulas.hbs
+++ b/templates/damage/formulas.hbs
@@ -1,0 +1,21 @@
+<section class="formulas">
+  <fieldset>
+    <legend>{{localize "DND.DIALOG.DAMAGE.PARTS"}}</legend>
+    {{#each parts}}
+    {{#if rule}}
+    <hr>
+    {{/if}}
+    <div class="form-group">
+      <div class="form-fields">
+        {{ formInput formula.field value=formula.value placeholder=formula.placeholder name=formula.name }}
+      </div>
+      <div class="controls flex0">
+        <button type="button" data-action="deletePart" data-idx="{{idx}}" data-tooltip="DND.DIALOG.DAMAGE.DELETE">
+          <i class="fa-solid fa-trash"></i>
+        </button>
+      </div>
+    </div>
+    {{ formGroup types.field value=types.value name=types.name label=(localize "DND.DIALOG.DAMAGE.TYPES")}}
+    {{/each}}
+  </fieldset>
+</section>


### PR DESCRIPTION
Adds a new `DamageFormulaDialog` for the `/damage` enricher. I believe this implements all the options:
- the `average` option for showing average values
- the `extended` option for showing an extended string (prefixed by "Hit:" and suffixed by "damage").
- allowing for any one part to be multiple types (which lets the user choose in the damage roll config)
- allowing for an arbitrary number of formulas

This was written on v13, but I took care not to use any API specific to the new version.

![image](https://github.com/user-attachments/assets/81ba760d-c27c-4daf-ab0e-6153585591b1)

![image](https://github.com/user-attachments/assets/125974f8-6fe5-418b-80bb-db7cc4f4b6c6)

![image](https://github.com/user-attachments/assets/cb292549-2dd3-49a3-9450-080d12b8e3c2)
